### PR TITLE
Add timestamp to PyPI command

### DIFF
--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -26,11 +26,11 @@ INVALID_INPUT_DELETE_DELAY = RedirectOutput.delete_delay
 log = get_logger(__name__)
 
 def _get_latest_distribution_timestamp(data: dict[str, typing.Any]) -> datetime | None:
-    """Get upload time of last distribution, or `None` if no distributions were found."""
+    """Get upload date of last distribution, or `None` if no distributions were found."""
     if not data["urls"]:
         return None
 
-    return max(arrow.get(dist["upload_time"]) for dist in data["urls"]).datetime
+    return max(arrow.get(dist["upload_time"]) for dist in data["urls"]).date()
 
 class PyPi(Cog):
     """Cog for getting information about PyPi packages."""
@@ -72,9 +72,9 @@ class PyPi(Cog):
                     else:
                         embed.description = "No summary provided."
 
-                    upload_time = _get_latest_distribution_timestamp(response_json)
-                    if upload_time:
-                        embed.timestamp = upload_time
+                    upload_date = _get_latest_distribution_timestamp(response_json)
+                    if upload_date:
+                        embed.set_footer(text=f"Uploaded to PyPI on {upload_date}")
 
                     error = False
 


### PR DESCRIPTION
Added the suggestion in [#2614](https://github.com/python-discord/bot/pull/2614) to switch to footer as per [Xithrius](https://github.com/Xithrius)

After brief [discussion](https://discord.com/channels/267624335836053506/635950537262759947/1206840886995193896) on discord I removed the time information and left it at date.

In the above linked issue it suggest to add more commits by pushing to this. Which is what I attempted here. Hope I did it right. If not, let me know!